### PR TITLE
Edit to QIIME2 installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ Then we need to download a file from the internet that tells our installer what 
 wget https://data.qiime2.org/distro/amplicon/qiime2-amplicon-2023.9-py38-linux-conda.yml
 ```
 
-Now we will create a conda environment for your new QIIME2 amplicon distribution and tell it what file to use (which is the one we just downloaded). Please be aware this might take a while:
+We need to edit this file to remove the conda defaults channel :
+
+```
+sed -i '/- defaults/d' qiime2-amplicon-2023.9-py38-linux-conda.yml
+```
+
+Now we will create a conda environment for your new QIIME2 amplicon distribution and tell it what file to use (which is the one we just downloaded and edited). Please be aware this might take a while:
 
 ```
 conda env create -n qiime2-amplicon-2023.9 --file qiime2-amplicon-2023.9-py38-linux-conda.yml


### PR DESCRIPTION
Added a line of code explaining how to remove the conda defaults channel from from the qiime2 yaml in the installation instructions. This should prevent the errors in installation due to the new anaconda channel restrictions on the HPC. 